### PR TITLE
Update publish_and_release.yml

### DIFF
--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -75,6 +75,7 @@ jobs:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_PUBLIC_KEY: ${{ secrets.TAURI_PUBLIC_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: "-"
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
 


### PR DESCRIPTION
Adding the APPLE_SIGNING_IDENTITY will make the installer not be trusted by MacOS systems but will allow a user to install the app and use it